### PR TITLE
Add terraform empty backend configuration block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+terraform {
+  backend "s3" {
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {


### PR DESCRIPTION
Add terraform empty backend configuration block for further usage of the module in terragrunt.