### PR TITLE
fix: update shared artifacts location. remove requirement to deploy i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ IAM Roles Anywhere allows your workloads such as servers, containers, and applic
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.54.0 |
+| <a name="provider_aws.aws-shared"></a> [aws.aws-shared](#provider\_aws.aws-shared) | 4.54.0 |
 
 ## Modules
 
@@ -45,9 +46,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_region_shared"></a> [aws\_region\_shared](#input\_aws\_region\_shared) | AWS Region of the shared resources. I.e Private Certificate Authority, S3 Bucket containing lambda sources | `string` | `"eu-central-1"` | no |
+| <a name="input_crl_lambda_name"></a> [crl\_lambda\_name](#input\_crl\_lambda\_name) | Name of the shared lambda function that will be used to check the CRL | `string` | `"crl-importer"` | no |
+| <a name="input_crl_lambda_path"></a> [crl\_lambda\_path](#input\_crl\_lambda\_path) | Path to the shared lambda function inside the shared lambda bucket that will be used to check the CRL, make sure to include the trailing slash | `string` | `"iam-rolesanywhere-lambdas/"` | no |
 | <a name="input_crl_name"></a> [crl\_name](#input\_crl\_name) | Name of the certificate revocation list (CRL) | `string` | n/a | yes |
 | <a name="input_crl_url"></a> [crl\_url](#input\_crl\_url) | URL of the certificate revocation list (CRL) | `string` | n/a | yes |
 | <a name="input_iam_role_actions"></a> [iam\_role\_actions](#input\_iam\_role\_actions) | Actions and the corresponding resource that are allowed to be actioned on by the assumed role | <pre>list(object({<br>    actions   = list(string)<br>    resources = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_shared_lambda_bucket_name"></a> [shared\_lambda\_bucket\_name](#input\_shared\_lambda\_bucket\_name) | Name of the S3 bucket where the shared lambda functions are stored | `string` | `"dfds-ce-shared-artifacts"` | no |
 | <a name="input_system_environment"></a> [system\_environment](#input\_system\_environment) | System Environment | `string` | `""` | no |
 | <a name="input_system_name"></a> [system\_name](#input\_system\_name) | Name of the application of service to be used with IAM Roles Anywhere | `string` | n/a | yes |
 | <a name="input_x509_certificate_data"></a> [x509\_certificate\_data](#input\_x509\_certificate\_data) | Bundled Certificate x509 Certificate Data | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,17 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias = "aws-shared"
+  region = var.aws_region_shared
+  default_tags {
+    tags = {
+      Environment = var.system_environment
+      System_name = var.system_name
+    }
+  }
+}
+
 resource "aws_iam_role" "this" {
   name               = "${var.system_name}-role"
   assume_role_policy = data.aws_iam_policy_document.role_trust_relationship.json
@@ -28,7 +39,7 @@ resource "aws_rolesanywhere_profile" "this" {
 }
 
 resource "aws_rolesanywhere_trust_anchor" "this" {
-  name    = "${var.system_name}-trust-achor"
+  name    = "${var.system_name}-trust-anchor"
   enabled = true
   source {
     source_data {

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,27 @@ variable "crl_url" {
     error_message = "The URL must include `https://`."
   }
 }
+
+variable "crl_lambda_name" {
+  type = string
+  description = "Name of the shared lambda function that will be used to check the CRL"
+  default = "crl-importer"
+}
+
+variable "crl_lambda_path" {
+  type = string
+  description = "Path to the shared lambda function inside the shared lambda bucket that will be used to check the CRL, make sure to include the trailing slash"
+  default = "iam-rolesanywhere-lambdas/"
+}
+
+variable "shared_lambda_bucket_name" {
+  type = string
+  description = "Name of the S3 bucket where the shared lambda functions are stored"
+  default = "dfds-ce-shared-artifacts"
+}
+
+variable "aws_region_shared" {
+  type = string
+  description = "AWS Region of the shared resources. I.e Private Certificate Authority, S3 Bucket containing lambda sources"
+  default = "eu-central-1"
+}


### PR DESCRIPTION
…n eu-central-1

This PR updates the shared artifacts location because it seems to have been migrated from the `dfds-iam-roles-anywhere-artifacts` bucket to `dfds-ce-shared-artifacts/iam-rolesanywhere-lambdas` and the change not reflected here. It also now uses a variable default so that it can be overridden if required instead of a hard-coded value.

The PR also removes the requirement for this module to be deployed in eu-central-1 (the region in which the shared resources are set), ensuring only the necessary resources are deployed in eu-central-1 to match the shared artifacts location.