### PR TITLE
chore: update lambda-crl-importer runtime

### DIFF
--- a/lambda-crl-importer.tf
+++ b/lambda-crl-importer.tf
@@ -8,8 +8,8 @@ resource "aws_lambda_function" "this" {
   timeout                        = 120
   memory_size                    = 512
   reserved_concurrent_executions = 1
-  runtime = "go1.x"
-  handler = "main"
+  runtime = "provided.al2"
+  handler = "bootstrap"
   s3_bucket = var.shared_lambda_bucket_name
   s3_key = "${var.crl_lambda_path}${local.lambda_name}-lambda.zip"
   source_code_hash = data.aws_s3_object.this.etag


### PR DESCRIPTION
This PR will update the lambda runtime because go1.x is now deprecated.

Do not merge until https://github.com/dfds/iam-rolesanywhere-lambdas/pull/4 is merged and release action is successful