### PR TITLE
fix: use var rather than assuming shared lambda name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ No modules.
 | <a name="input_crl_lambda_name"></a> [crl\_lambda\_name](#input\_crl\_lambda\_name) | Name of the shared lambda function that will be used to check the CRL | `string` | `"crl-importer"` | no |
 | <a name="input_crl_lambda_path"></a> [crl\_lambda\_path](#input\_crl\_lambda\_path) | Path to the shared lambda function inside the shared lambda bucket that will be used to check the CRL, make sure to include the trailing slash | `string` | `"iam-rolesanywhere-lambdas/"` | no |
 | <a name="input_crl_name"></a> [crl\_name](#input\_crl\_name) | Name of the certificate revocation list (CRL) | `string` | n/a | yes |
+| <a name="input_crl_shared_lambda_name"></a> [crl\_shared\_lambda\_name](#input\_crl\_shared\_lambda\_name) | Name of the shared lambda function zip file in the shared bucket in the shared bucket that will be used to check the CRL | `string` | `"crl-importer"` | no |
 | <a name="input_crl_url"></a> [crl\_url](#input\_crl\_url) | URL of the certificate revocation list (CRL) | `string` | n/a | yes |
 | <a name="input_iam_role_actions"></a> [iam\_role\_actions](#input\_iam\_role\_actions) | Actions and the corresponding resource that are allowed to be actioned on by the assumed role | <pre>list(object({<br>    actions   = list(string)<br>    resources = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_shared_lambda_bucket_name"></a> [shared\_lambda\_bucket\_name](#input\_shared\_lambda\_bucket\_name) | Name of the S3 bucket where the shared lambda functions are stored | `string` | `"dfds-ce-shared-artifacts"` | no |

--- a/lambda-crl-importer.tf
+++ b/lambda-crl-importer.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "this" {
   runtime = "provided.al2"
   handler = "bootstrap"
   s3_bucket = var.shared_lambda_bucket_name
-  s3_key = "${var.crl_lambda_path}${local.lambda_name}-lambda.zip"
+  s3_key = "${var.crl_lambda_path}${var.crl_shared_lambda_name}-lambda.zip"
   source_code_hash = data.aws_s3_object.this.etag
 
   environment {
@@ -31,7 +31,7 @@ resource "aws_lambda_function" "this" {
 
 data "aws_s3_object" "this" {
   bucket = var.shared_lambda_bucket_name
-  key    = "${var.crl_lambda_path}${local.lambda_name}-lambda.zip"
+  key    = "${var.crl_lambda_path}${var.crl_shared_lambda_name}-lambda.zip"
   provider = aws.aws-shared
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -70,3 +70,9 @@ variable "aws_region_shared" {
   description = "AWS Region of the shared resources. I.e Private Certificate Authority, S3 Bucket containing lambda sources"
   default = "eu-central-1"
 }
+
+variable "crl_shared_lambda_name" {
+  type = string
+  description = "Name of the shared lambda function zip file in the shared bucket in the shared bucket that will be used to check the CRL"
+  default = "crl-importer"
+}


### PR DESCRIPTION
This PR ultimately allows multiple deployments in the same account by not assuming the shared lambda name