### PR TITLE
fix: allow lambdas to be deployed in region other than eu-central-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ IAM Roles Anywhere allows your workloads such as servers, containers, and applic
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.31.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.54.0 |
-| <a name="provider_aws.aws-shared"></a> [aws.aws-shared](#provider\_aws.aws-shared) | 4.54.0 |
 
 ## Modules
 
@@ -40,20 +39,20 @@ No modules.
 | [aws_iam_policy_document.lambda_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.role_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_s3_object.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_object) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_region_shared"></a> [aws\_region\_shared](#input\_aws\_region\_shared) | AWS Region of the shared resources. I.e Private Certificate Authority, S3 Bucket containing lambda sources | `string` | `"eu-central-1"` | no |
 | <a name="input_crl_lambda_name"></a> [crl\_lambda\_name](#input\_crl\_lambda\_name) | Name of the shared lambda function that will be used to check the CRL | `string` | `"crl-importer"` | no |
 | <a name="input_crl_lambda_path"></a> [crl\_lambda\_path](#input\_crl\_lambda\_path) | Path to the shared lambda function inside the shared lambda bucket that will be used to check the CRL, make sure to include the trailing slash | `string` | `"iam-rolesanywhere-lambdas/"` | no |
 | <a name="input_crl_name"></a> [crl\_name](#input\_crl\_name) | Name of the certificate revocation list (CRL) | `string` | n/a | yes |
 | <a name="input_crl_shared_lambda_name"></a> [crl\_shared\_lambda\_name](#input\_crl\_shared\_lambda\_name) | Name of the shared lambda function zip file in the shared bucket in the shared bucket that will be used to check the CRL | `string` | `"crl-importer"` | no |
 | <a name="input_crl_url"></a> [crl\_url](#input\_crl\_url) | URL of the certificate revocation list (CRL) | `string` | n/a | yes |
 | <a name="input_iam_role_actions"></a> [iam\_role\_actions](#input\_iam\_role\_actions) | Actions and the corresponding resource that are allowed to be actioned on by the assumed role | <pre>list(object({<br>    actions   = list(string)<br>    resources = list(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_shared_lambda_bucket_name"></a> [shared\_lambda\_bucket\_name](#input\_shared\_lambda\_bucket\_name) | Name of the S3 bucket where the shared lambda functions are stored | `string` | `"dfds-ce-shared-artifacts"` | no |
+| <a name="input_shared_lambda_bucket_name"></a> [shared\_lambda\_bucket\_name](#input\_shared\_lambda\_bucket\_name) | Name of the S3 bucket where the shared lambda functions are stored | `string` | `"dfds-rf-ce-shared-artifacts"` | no |
 | <a name="input_system_environment"></a> [system\_environment](#input\_system\_environment) | System Environment | `string` | `""` | no |
 | <a name="input_system_name"></a> [system\_name](#input\_system\_name) | Name of the application of service to be used with IAM Roles Anywhere | `string` | n/a | yes |
 | <a name="input_x509_certificate_data"></a> [x509\_certificate\_data](#input\_x509\_certificate\_data) | Bundled Certificate x509 Certificate Data | `string` | n/a | yes |

--- a/data.tf
+++ b/data.tf
@@ -39,3 +39,5 @@ data "aws_iam_policy_document" "role_policy" {
     }
   }
 }
+
+data "aws_region" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -12,17 +12,6 @@ provider "aws" {
   }
 }
 
-provider "aws" {
-  alias = "aws-shared"
-  region = var.aws_region_shared
-  default_tags {
-    tags = {
-      Environment = var.system_environment
-      System_name = var.system_name
-    }
-  }
-}
-
 resource "aws_iam_role" "this" {
   name               = "${var.system_name}-role"
   assume_role_policy = data.aws_iam_policy_document.role_trust_relationship.json

--- a/variables.tf
+++ b/variables.tf
@@ -62,13 +62,7 @@ variable "crl_lambda_path" {
 variable "shared_lambda_bucket_name" {
   type = string
   description = "Name of the S3 bucket where the shared lambda functions are stored"
-  default = "dfds-ce-shared-artifacts"
-}
-
-variable "aws_region_shared" {
-  type = string
-  description = "AWS Region of the shared resources. I.e Private Certificate Authority, S3 Bucket containing lambda sources"
-  default = "eu-central-1"
+  default = "dfds-rf-ce-shared-artifacts"
 }
 
 variable "crl_shared_lambda_name" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.50.0"
+      version = ">= 5.31.0"
     }
   }
 }


### PR DESCRIPTION
This PR will allow lambdas to be supported in the desired region without being forced into the same region as the deployed lambda source. It works in conjunction with multi-region support in the ce-shared artifacts s3 bucket which was added with: https://github.com/dfds/ce-shared/pull/1

Due to a suspected bug with aws_lambda_function terraform resource not allowing mrap arn's in its bucket_name field, we are not using the multi-region access point but instead calculating the appropriate bucket name based on region